### PR TITLE
Change name of rule for trailing commas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,9 +100,9 @@ Style/StringLiterals:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylestringliterals
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Enabled: false
-  StyleGuide: http://relaxed.ruby.style/#styletrailingcomma
+  StyleGuide: http://relaxed.ruby.style/#styletrailingcommainliteral
 
 Style/WhileUntilModifier:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Refering to [two-letter version of special global variables](http://idiosyncrati
 [Disabled rule](https://github.com/bbatsov/ruby-style-guide#consistent-string-literals).
 Deliberately use single or double quoted strings!
 
-### Style/TrailingComma
+### Style/TrailingCommaInLiteral
 
 [Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas).
 Use trailing commas in multi-line literals. It makes manipulating the literal easier


### PR DESCRIPTION
the current version of rubocop spits out this error message:

Error: The `Style/TrailingComma` cop no longer exists. Please use
`Style/TrailingCommaInLiteral` and/or `Style/TrailingCommaInArguments`
instead.

From the description the trailing comma rule should only apply to
trailing commas in literals. So I changed it accordingly
