### PR TITLE
Support Rubocop 0.53.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,9 +113,13 @@ Style/TrailingCommaInArguments:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styletrailingcommainarguments
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
-  StyleGuide: http://relaxed.ruby.style/#styletrailingcommainliteral
+  StyleGuide: http://relaxed.ruby.style/#styletrailingcommainarrayliteral
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styletrailingcommainhashliteral
 
 Style/WhileUntilModifier:
   Enabled: false


### PR DESCRIPTION
Rubocop 0.53.0 splits `Style/TrailingCommaInLiteral` into
`Style/TrailingCommaInArrayLiteral` and
`Style/TrailingCommaInHashLiteral`

Closes #4