### PR TITLE
Update references to the community Ruby style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Version 2.3
 
-A more liberal style guide for [RuboCop](https://github.com/bbatsov/rubocop). It comes
+A more liberal style guide for [RuboCop](https://github.com/rubocop-hq/rubocop). It comes
 with a [config file](https://relaxed.ruby.style/rubocop.yml) that deactivates some of
 RuboCop's features. It is meant as a less restrictive foundation that you can use
 directly or base your style discussions on.
@@ -17,7 +17,7 @@ might distract you from the helpful messages.
 ### How to Read this Style Guide
 
 This is not a stand-alone style guide, but a patch applied to
-[bbatsov/ruby-style-guide](https://github.com/bbatsov/ruby-style-guide)
+[rubocop-hq/ruby-style-guide](https://github.com/rubocop-hq/ruby-style-guide)
 (the style guide RuboCop is based on).
 
 ### Usage
@@ -41,7 +41,7 @@ And in your `.rubocop.yml`:
 
 ### Style/Alias
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#alias-method). Feel free to
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#alias-method). Feel free to
 use the `alias` keyword when appropriate.
 
 ### Style/AsciiComments
@@ -51,17 +51,17 @@ encoding is UTF-8, you can use UTF-8 characters in comments.
 
 ### Style/BeginBlock
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks). Use `BEGIN`
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-BEGIN-blocks). Use `BEGIN`
 blocks when you need its functionality.
 
 ### Style/BlockDelimiters
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#single-line-blocks).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#single-line-blocks).
 Consider [using `{}` for multi-line blocks](https://github.com/chneukirchen/styleguide/blob/e60de37b478d3f892f6985a58d573016f33f0269/RUBY-STYLE#L63-L67).
 
 ### Style/CommentAnnotation
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#annotate-keywords). It is
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#annotate-keywords). It is
 totally optional to put a colon and a space behind **TODO**s and **FIXME**s
 
 ### Style/Documentation
@@ -71,81 +71,81 @@ method and variable names!
 
 ### Layout/DotPosition
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#consistent-multi-line-chains).
 When chaining methods on multiple lines, it is a good idea to put the dots at the end of
 the lines to indicate that the expression continues on the next line.
 
 ### Style/DoubleNegation
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-bang-bang). Use `!!variable`
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-bang-bang). Use `!!variable`
 to get the boolean value of a variable.
 
 ### Style/EndBlock
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-END-blocks). Use `END`
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-END-blocks). Use `END`
 blocks or `Kernel#at_exit` for code that should be executed when the program quits.
 
 ### Style/FormatString
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#sprintf). Creating format
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#sprintf). Creating format
 string should be done using the [`String#%` method](https://idiosyncratic-ruby.com/49-what-the-format.html).
 
 ### Style/IfUnlessModifier
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier). Use or
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#if-as-a-modifier). Use or
 don't use `if`/`unless` in modifier style whenever you think it improves code readability.
 
 ### Style/Lambda
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#lambda-multi-line). It does
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#lambda-multi-line). It does
 not matter if you use `->(){}` or `lambda{}` to create lambdas.
 
 ### Style/ModuleFunction
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#module-function). Prefer
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#module-function). Prefer
 `extend self` over `module_function`. It uses Ruby's inheritance chain, instead of
 copying all methods. Less magic!
 [More info](https://idiosyncratic-ruby.com/8-self-improvement.html).
 
 ### Style/MultilineBlockChain
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#single-line-blocks). Chain
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#single-line-blocks). Chain
 multiple blocks when it makes sense, this promotes a functional programming mindset.
 
 ### Style/NegatedIf
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#unless-for-negatives). Always
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#unless-for-negatives). Always
 use `if !condition` for complex conditions with negations. For simple conditions, for
 which it also unlikely that an else clause will be added at some later point, it is also
 OK to use `unless condition`.
 
 ### Style/NegatedWhile
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#until-for-negatives). Always
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#until-for-negatives). Always
 use `while !condition` for complex conditions with negations. For simple conditions,
 it is also OK to use `until condition`.
 
 ### Style/ParallelAssignment
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#parallel-assignment).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#parallel-assignment).
 Parallel assignment can sometimes express the intented logic better than sequential
 assignment. It is also [faster](https://github.com/JuanitoFatas/fast-ruby#parallel-assignment-vs-sequential-assignment-code).
 
 ### Style/PercentLiteralDelimiters
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#percent-literal-braces). When
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#percent-literal-braces). When
 creating literals with the `%` syntax, choose any delimiters that don't interfere with
 the literal's content.
 
 ### Style/PerlBackrefs
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-perl-regexp-last-matchers).
 It is fine to use the special **local** variables `$1` - `$9` to access the contents of
 your last matched regex groups.
 
 ### Style/Semicolon
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-semicolon). Usage of
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-semicolon). Usage of
 semicolons to separate multiple statements is OK.
 
 ### Style/SignalException
@@ -159,7 +159,7 @@ exceptions with `raise` or `fail`.
 
 ### Style/SingleLineMethods
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-single-line-methods).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-single-line-methods).
 Single-line methods can be useful for short getter- or setter-like methods, when
 `attr_reader` / `attr_accessor` / `attr_writer` are not enough anymore.
 
@@ -169,35 +169,35 @@ It is not important if there is a space between a method call and a passed block
 
 ### Layout/SpaceInsideParens
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-spaces-braces). Avoid
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-spaces-braces). Avoid
 putting spaces inside parentheses, but do it when it improves readability.
 For example, when using RSpec's `expect` method.
 
 ### Style/SpecialGlobalVars
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-cryptic-perlisms).
 Refering to [two-letter version of special global variables](https://idiosyncratic-ruby.com/9-globalization.html#list-of-all-special-global-variables) is OK, although not very polite.
 
 ### Style/StringLiterals
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#consistent-string-literals).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#consistent-string-literals).
 Deliberately use single or double quoted strings!
 
 ### Style/TrailingCommaInArguments
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-trailing-params-comma).
 Use trailing commas in multi-line argument lists. It makes manipulating the params easier
 (reordering, appending, removing) and leads to smaller git diffs. Consider using RuboCop's
 `EnforcedStyleForMultiline: consistent_comma` option.
 
 ### Style/SymbolArray
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#percent-i). You can use the
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#percent-i). You can use the
 `%i` syntax for an array of symbols, but usage of an array of symbols is fine, too.
 
 ### Style/TrailingCommaInLiteral
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#no-trailing-array-commas).
 Use trailing commas in multi-line literals. It makes manipulating the literal easier
 (reordering, appending, removing) and leads to smaller git diffs. Consider using RuboCop's
 `EnforcedStyleForMultiline: consistent_comma` option.
@@ -211,7 +211,7 @@ to use.
 
 ### Style/WhileUntilModifier
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier). Use or
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#while-as-a-modifier). Use or
 don't use `while`/`until` in modifier style whenever you think it improves code
 readability.
 
@@ -221,7 +221,7 @@ Use regex normally.
 
 ### Lint/AssignmentInCondition
 
-[Disabled rule](https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition).
+[Disabled rule](https://github.com/rubocop-hq/ruby-style-guide#safe-assignment-in-condition).
 Use `=` for assignments in conditions. Use `==` for comparisons in conditions.
 
 ### Metrics
@@ -233,7 +233,7 @@ be discussed, tweaked and activated individually.
 
 * [Leah Neukirchen](https://github.com/chneukirchen/styleguide/blob/master/RUBY-STYLE)
 * [Fast Ruby](https://github.com/JuanitoFatas/fast-ruby)
-* [Ruby Style Guide (Rubocop)](https://github.com/bbatsov/ruby-style-guide/)
+* [Ruby Style Guide (RuboCop)](https://github.com/rubocop-hq/ruby-style-guide/)
   * [GitHub](https://github.com/styleguide/ruby)
   * [Airbnb](https://github.com/airbnb/ruby)
   * [Shopify](https://shopify.github.io/ruby-style-guide/)


### PR DESCRIPTION
It's also published under https://rubystyle.guide these days.